### PR TITLE
added file transfer and additional info page

### DIFF
--- a/docs/cubic/cubic.md
+++ b/docs/cubic/cubic.md
@@ -398,6 +398,29 @@ $ pgrep -lf sshfs
 $ kill -9 <pid_of_sshfs_process>
 $ sudo umount -f <mounted_dir>
 ```
+## Moving data to and from CUBIC
+Because of CUBIC's unique "project user" design, the protocol for moving files to CUBIC is a bit different than on a normal cluster. It is possible to move files to CUBIC by conventional means, or through your mount point, but this can cause annoying permissions issues and is not recommended.
+
+Note that you will need to be within the UPenn infrastructure (i.e. on VPN or on campus) to move files to and from CUBIC.
+
+### Moving files to CUBIC
+All project directories will include a folder called `dropbox/` in the project home directory. Depositing files into this folder will automatically make the project user the owner of the file. Please note, however, that this ownership conversion is not always instantaneous and can take a few minutes, so be patient. Note also that anyone in the project group can move files into this folder. Finally, keep in mind that the dropbox can only contain 1GB or 1000 files at any given time. 
+
+`scp` is the recommended command-line transfer software for moving files onto and off of CUBIC. One need only specify the file(s) to move and the CUBIC destination. See the example below, where `<...>` indicates user input:
+
+`scp </path/to/files*.nii.gz> <username>@cubic-login.uphs.upenn.edu:/cbica/projects/<project_dir>/dropbox/` 
+
+This command would copy all `nii.gz` files from `/path/to/` into the `dropbox/` folder of your project directory. Note that you are entering your CUBIC username in the destination, not your project username (confusing, I know).
+
+Moving files directly to a non `dropbox/` folder on CUBIC with scp or your mount point *is* possible for a user with project directory write permissions, though is not recommended. Such files will retain the ownership of the CUBIC user who transferred the files, and permissions can only be changed by that user or a user with sudo priveleges. 
+
+### Moving files from CUBIC
+This is much simpler. One can simply use scp (or rsync, or whatever) to copy files from a source on cubic to their local destination. E.g.
+
+`scp <username>@cubic-login.uphs.upenn.edu:/cbica/projects/<project_dir/path/files.csv> </local/path/to/put/files/>`
+
+It is also possible to copy files through the mount point, but this would be quite slow and is not really the purpose of the mount point.
+
 
 ##  Using R/R-studio and Installation of  R packages
 
@@ -481,4 +504,7 @@ If you see this:
 
 Note that the use of `h_vmem` adds 2.5 GBs to the original `mem_gb` specification. This is to remain on the safe side of memory specification to the cluster as the cluster will kill any job that uses more than the requested memory space when requesting hard memory (`h_vmem`). This function is used to save space on the cluster such that several jobs can be run simultaneously but is only advised to be used when the user is sure about the memory specification needed. 
 
-Note that `s_vmem` adds only 2 GBs to the original `mem_gb` specification. This is because soft memory has more flexibility than hard memory specifications. This is recommended to be used when the exact memory required by each subject is not concretely known so as to diminish the risk of the job being killed by accident. 
+Note that `s_vmem` adds only 2 GBs to the original `mem_gb` specification. This is because soft memory has more flexibility than hard memory specifications. This is recommended to be used when the exact memory required by each subject is not concretely known so as to diminish the risk of the job being killed by accident.
+
+## Additional information about CUBIC
+[This page](https://cbica-wiki.uphs.upenn.edu/wiki/index.php/Research_Projects) has tons of other useful information about using CUBIC. Anyone who plans on using CUBIC regularly should probably browse it. Also, when troubleshooting, make sure the answer to your question isn't on this page before asking others. Note that you will need to be within the UPenn infrastructure (i.e. on campus or using a VPN) to view this page.


### PR DESCRIPTION
I added two new sections: "Moving files to and from CUBIC", and "Additional information about CUBIC" at the bottom. The former discusses the weird dropbox situation, the latter links to [this website](https://cbica-wiki.uphs.upenn.edu/wiki/index.php/Research_Projects). 

Not sure if I need to do anything for the TOC to update. Also, I'm still kind of a CUBIC newb (coob newb?) so if any of this is wrong please do correct/edit/delete/reject as you see fit.  

@TinasheMTapera @mb3152 