### PR TITLE
📝 Clarify Datalad / bootstrap documentation

### DIFF
--- a/docs/TheWay/RunningDataLadPipelines.md
+++ b/docs/TheWay/RunningDataLadPipelines.md
@@ -38,7 +38,7 @@ singularity build qsiprep-0.14.2.sif docker://pennbbl/qsiprep:0.14.2
 ```
 
 This image needs to be added to a datalad "containers dataset". Be sure you've installed
-the datalad containers plugin via `pip install datalad_containers`. Now create the
+the datalad containers plugin via `pip install datalad_container`. Now create the
 dataset:
 
 ```bash
@@ -111,7 +111,7 @@ jobs on the cluster.
 ```bash
 $ cd ${BIDSAPP}
 $ ls
-analysis	input_ria	output_ria
+analysis	input_ria	output_ria	pennlinc-containers
 $ cd analysis
 $ datalad siblings
 .: here(+) [git]

--- a/docs/TheWay/RunningDataLadPipelines.md
+++ b/docs/TheWay/RunningDataLadPipelines.md
@@ -76,7 +76,7 @@ to the lowercase version of the pipeline you'd like to run.
 Different bootstrap scripts require different argmuents. For BIDSApps, the arguments are
 
   1. The datalad-interpretable path to your BIDS dataset. Examples may be ria+ssh://, ria+file://,
-     https:// or a path to a local datalad-enabled directory containing BIDS data. If a local path, it should be the directory that contains the `sub-`directories and **must** be a datalad dataset.
+     https:// or a path to a local datalad-enabled directory containing BIDS data. If a local path, `/full/path/to/BIDS` should be the directory that contains the `sub-` directories as children (one level of depth) and **must** be a datalad dataset.
   2. The path to the container dataset you created in the previous step.
 
 ---


### PR DESCRIPTION
In working on setting up [a bootstrap script for C-PAC](https://github.com/FCP-INDI/TheWay/blob/9ef4c02d618d54982165e65549ea54fe529dc939/scripts/cubic/bootstrap-c-pac.sh), these are the only clarifications I made in my fork of the existing docs:

* Correct name of [`datalad-container`](https://pypi.org/project/datalad-container/)~~`s`~~
* Add `pennlinc-containers` to the expected `ls` output in the `${BIDSAPP}` directory
* Clarify that `full/path/to/bids` is direct parent of `sub-*` directories