### PR TITLE
Remove mention of Trello

### DIFF
--- a/docs/LabHome/ProjectMeetings.md
+++ b/docs/LabHome/ProjectMeetings.md
@@ -7,21 +7,18 @@ nav_order: 2
 
 # Project Meetings with Ted
 
-All PennLINC team members lead a scientific project.  
+All PennLINC team members lead a scientific project.
 
 ## Scheduling
 
-For each of these projects, members typically meet weekly with Ted. However, if there has been limited progress due to other competing demands, meetings can be spaced to every other week (send Ted a brief note). In general, we try to avoid scheduling meetings without a clear agenda. These are scheduled by the trainee on a google calendar, which Ted will give you access to, and permissions to make new meetings.  Weekly Ted will open up slots marked “OPEN FOR MEETINGS” on this calendar; a note will be posted to the #WhereAmI channel on Slack when these meeting times are posted.  Typically, meetings are 30 minutes, except in specific cases when a 45-minute or 60-minute meeting is necessary (pls discuss prospectively).  To allow for a brief reprieve within long meeting blocks, meetings begin  5 minutes after the selected slot begins, and will end promptly on time. 
+For each of these projects, members typically meet weekly with Ted. However, if there has been limited progress due to other competing demands, meetings can be spaced to every other week (send Ted a brief note). In general, we try to avoid scheduling meetings without a clear agenda. These are scheduled by the trainee on a google calendar, which Ted will give you access to, and permissions to make new meetings.  Weekly Ted will open up slots marked “OPEN FOR MEETINGS” on this calendar; a note will be posted to the #WhereAmI channel on Slack when these meeting times are posted.  Typically, meetings are 30 minutes, except in specific cases when a 45-minute or 60-minute meeting is necessary (pls discuss prospectively).  To allow for a brief reprieve within long meeting blocks, meetings begin  5 minutes after the selected slot begins, and will end promptly on time.
 
 ### Secondary mentor
 
-For projects led by junior trainees (i.e., CRCs, new data analysts, and rotating graduate students), Ted will identify a more-experienced team member (i.e., senior grad student, post-doc, or staff scientist) as a secondary/mid-level mentor.  This is critical, as the mid-level mentor tends to be both a) more available and b) more technically skilled.   The junior trainee should typically also have a separate 1:1 meeting with the mid-level mentor one or more times per week outside of the weekly meeting with Ted.   The mid-level mentor usually is the second author on the paper, and serves as the “replication buddy” (see [project reproducibility guide]( https://pennlinc.github.io/docs/LabHome/ReproSystem/)). For more experineced team members project meetings are often 1:1; it is still a very good idea to identify the reprobilibuddy early on in the project. 
+For projects led by junior trainees (i.e., CRCs, new data analysts, and rotating graduate students), Ted will identify a more-experienced team member (i.e., senior grad student, post-doc, or staff scientist) as a secondary/mid-level mentor.  This is critical, as the mid-level mentor tends to be both a) more available and b) more technically skilled.   The junior trainee should typically also have a separate 1:1 meeting with the mid-level mentor one or more times per week outside of the weekly meeting with Ted.   The mid-level mentor usually is the second author on the paper, and serves as the “replication buddy” (see [project reproducibility guide]( https://pennlinc.github.io/docs/LabHome/ReproSystem/)). For more experineced team members project meetings are often 1:1; it is still a very good idea to identify the reprobilibuddy early on in the project.
 
 ### Preparation
 
-For these meetings, please update the trello board ahead of the meeting so project progress can be clearly tracked. My preference is that data at these meetings is presented in the form of RMarkdown or Juypter notebooks to enhance reproducibility, although images in power point slide decks can be acceptable as well.
-
-
-
-
-
+For these meetings, please update the GitHub project board ahead of the meeting so project progress can be clearly tracked.
+My preference is that data at these meetings is presented in the form of RMarkdown or Juypter notebooks to enhance reproducibility,
+although images in power point slide decks can be acceptable as well.


### PR DESCRIPTION
I'm guessing Ted removed the Trello sections during the docathon, so this just deals with the lab remaining mention. Closes #70.