### PR TITLE
Link to lab website and remove duplicate navbar entry

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@
 # you will see them accessed via {{ site.title }}, {{ site.github_repo }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: Penn LINC Neuroinformatics
+title: PennLINC Lab Manual
 description: Informatics tutorials
 baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://PennLINC.github.io" # the base hostname & protocol for your site, e.g. http://example.com

--- a/_config.yml
+++ b/_config.yml
@@ -112,9 +112,10 @@ aux_links_new_tab: false
 nav_sort: case_sensitive # Capital letters sorted before lowercase
 
 # External navigation links
-# nav_external_links:
-#   - title: Just the Docs on GitHub
-#     url: https://github.com/just-the-docs/just-the-docs
+nav_external_links:
+  - title: Lab Website
+    url: https://pennlinc.io
+    opens_in_new_tab: true
 
 # Footer content
 # appears at the bottom of every page's main content

--- a/docs/documentation/documentation_guidelines.md
+++ b/docs/documentation/documentation_guidelines.md
@@ -55,7 +55,7 @@ In this case, you can create a new file right from the Github:
 <img src="/assets/images/adding_a_new_file.png" alt="">
 
 {: .note-title }
-> Warning
+> Tip
 >
 > You don't have to explicitly create folders in the Github web interface;
 > just type out your filename and path with backslashes and Github will automatically create the directory structure for you.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Welcome
-nav_order: 1
+nav_exclude: true
 description: "Welcome"
 permalink: /
 ---


### PR DESCRIPTION
- Adds an external link to the lab website (pennlinc.io) to the navbar.
- Removes the duplicate navbar entry for the home page. We can access it from the top of the navbar.
- Rename site from "Penn LINC Neuroinformatics" to "PennLINC Lab Manual".