### PR TITLE
Update meeting docs

### DIFF
--- a/docs/LabHome/Meetings/LabMeetings.md
+++ b/docs/LabHome/Meetings/LabMeetings.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Lab Meetings
-parent: Lab Basics
-nav_order: 2
+parent: Meetings
+grand_parent: Lab Basics
 ---
 
 

--- a/docs/LabHome/Meetings/OpenMeetings.md
+++ b/docs/LabHome/Meetings/OpenMeetings.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Open Meetings
+parent: Meetings
+grand_parent: Lab Basics
+---
+ ## Open Meetings
+
+There are several reoccuring meetings at PennLINC. Please see the table below for details.
+
+| Meeting Name                 | Point Person | Meeting Day | Meeting Time | Occurence | Slack Channel |
+|:-----------------------------|:-------------|:------------|:-------------|:----------|:-------------------------------------|
+| Lab Meeting                  | Juliette     | Tuesday     | 3:30 PM      | weekly    | #pennlinc_team and #pennlinc_general |
+| Richards Roundtable          | Audrey       | Wednesday   | 3:30 PM      | biweekly  | #richards_roundtable |
+| Informatics                  | Matt         | Daily       | 9:45 AM      | daily     | #informatics |
+| Sex Differences Journal Club | Laura        | Tuesday     | 1:30 PM      | biweekly  | #sdjc |

--- a/docs/LabHome/Meetings/ProjectMeetings.md
+++ b/docs/LabHome/Meetings/ProjectMeetings.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Project Meetings
-parent: Lab Basics
-nav_order: 2
+parent: Meetings
+grand_parent: Lab Basics
 ---
 
 # Project Meetings with Ted

--- a/docs/LabHome/Meetings/Seminars.md
+++ b/docs/LabHome/Meetings/Seminars.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Talks and Seminars
-parent: Lab Basics
-nav_order: 3
+parent: Meetings
+grand_parent: Lab Basics
 ---
 
 # Seminars and Talks at Penn

--- a/docs/LabHome/Meetings/index.md
+++ b/docs/LabHome/Meetings/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Meetings
+parent: Lab Basics
+has_children: true
+has_toc: true
+---
+
+# Meetings
+
+Here, you will find details regarding the different types of meetings at PennLINC.


### PR DESCRIPTION
This PR moved all meeting related pages to a Meetings subfolder in Lab Basics.
It further added a brief overview of reoccurring meetings at Pennlinc.

Question: On the new "Open Meetings" page, the table included links to the zoom meetings in notion. I wasn't sure if they should be added here as well as that would make them publicly available. If you want me to add them, just let me know!