### PR TITLE
Revise git config instructions

### DIFF
--- a/docs/cubic/cubic.md
+++ b/docs/cubic/cubic.md
@@ -246,7 +246,7 @@ The steps to do this are as follows:
     -   Choose the repositories that are relevant for the project.
     -   Longest expiration time allowed (366 days).
     -   Read access to metadata.
-    -   Read and Write access to code, commit statuses, and pull requests.
+    -   Read and Write access to contents, commit statuses, and pull requests.
 4.  `git config --global credential.helper store`
     -   This will store the PAT in ~/.git-credentials.
         It's plain text, but not an issue since we only have one repo.

--- a/docs/cubic/cubic.md
+++ b/docs/cubic/cubic.md
@@ -241,20 +241,22 @@ The steps to do this are as follows:
 
 1.  `git config --global user.name <username>`
 2.  `git config --global user.email <email>`
-3.  Create fine-grained PAT on GitHub.
+3.  `git config --global credential.helper store`
+    -   This will store the PAT in ~/.git-credentials.
+        It's plain text, but not an issue since we only have one repo.
+4.  `git clone https://github.com/PennLINC/affective-instability.git`
+    -   Must be HTTPS
+5.  Create fine-grained PAT on GitHub.
     -   Resource owner is PennLINC.
     -   Choose the repositories that are relevant for the project.
     -   Longest expiration time allowed (366 days).
     -   Read access to metadata.
     -   Read and Write access to contents, commit statuses, and pull requests.
-4.  `git config --global credential.helper store`
-    -   This will store the PAT in ~/.git-credentials.
-        It's plain text, but not an issue since we only have one repo.
-5.  `git clone https://github.com/PennLINC/affective-instability.git`
-    -   Must be HTTPS
-6.  Put in the username.
-7.  Put in the PAT.
-8.  Now you can make commits without needing to enter your credentials!
+    -   Copy the newly generated key to your clipboard.
+6.  Now if you commit a change and run `git push` you will be asked to provide credentials:
+    -   Put in the username.
+    -   Paste the PAT.
+7.  Going forward, you can push commits without needing to enter your credentials! (until that PAT expires)
 
 
 # Interacting with CUBIC: data analysis and data transfer

--- a/docs/cubic/cubic.md
+++ b/docs/cubic/cubic.md
@@ -244,7 +244,8 @@ The steps to do this are as follows:
 3.  `git config --global credential.helper store`
     -   This will store the PAT in ~/.git-credentials.
         It's plain text, but not an issue since we only have one repo.
-4.  `git clone https://github.com/PennLINC/affective-instability.git`
+4.  `git clone https://github.com/PennLINC/<repo>.git code`
+    - This will clone the repository into a new folder named "code".
     -   Must be HTTPS
 5.  Create fine-grained PAT on GitHub.
     -   Resource owner is PennLINC.


### PR DESCRIPTION
changed order so that user could copy/paste quickly after PAT generation. Added instructions to have user trigger the sign-in query 